### PR TITLE
Logback configuration

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,7 +15,7 @@
         <file>logs/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 
-            <fileNamePattern>logs/application_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/application_%d{yyyy-MM-dd}.log</fileNamePattern>
 
             <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
                 <maxFileSize>5MB</maxFileSize>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <timestamp key="byDay" datePattern="yyyy-MM-dd"/>
 
     <!-- ========================= Appenders ======================= -->
 
@@ -30,13 +29,11 @@
         </encoder>
     </appender>
 
-    <!-- ========================= Root ======================= -->
+    <!-- ========================= Loggers ======================= -->
 
-    <!-- The level of the root is set to INFO -->
-    <root level="INFO">
+    <logger name="com.sysgears.seleniumbundle" level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>
-    </root>
-
+    </logger>
 
 </configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
         <file>logs/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 
-            <fileNamePattern>logs/application_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/application_%d{yyyy-MM-dd}.log</fileNamePattern>
 
             <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
                 <maxFileSize>5MB</maxFileSize>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <timestamp key="byDay" datePattern="yyyy-MM-dd"/>
 
     <!-- ========================= Appenders ======================= -->
 
@@ -32,16 +31,9 @@
 
     <!-- ========================= Loggers ======================= -->
 
-    <logger name="com.sysgears.seleniumbundle" level="INFO" additivity="false">
+    <logger name="com.sysgears.seleniumbundle" level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>
     </logger>
-
-    <!-- ========================= Root ======================= -->
-
-    <!-- By default, the level of the root level is set to DEBUG -->
-    <root level="DEBUG">
-    </root>
-
 
 </configuration>


### PR DESCRIPTION
In version 1.1.7 of logback-classic, the configuration of the library has changed and the token "%i" has become incompatible to use in fileNamePattern. 